### PR TITLE
WIP: Make RasterSequence aware of axis types

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -63,7 +63,8 @@ testpaths = "sunraster" "docs"
 norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "examples" ".history"
 doctest_plus = enabled
 doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
-addopts = -p no:warnings --doctest-rst
+#addopts = -p no:warnings --doctest-rst
+addopts = -p no:warnings
 markers =
     online: marks this test function as needing online connectivity.
 # Disable internet access for tests not marked remote_data

--- a/sunraster/__init__.py
+++ b/sunraster/__init__.py
@@ -24,4 +24,5 @@ if sys.version_info < tuple(int(val) for val in __minimum_python_version__.split
     raise UnsupportedPythonError(
         f"sunraster does not support Python < {__minimum_python_version__}")
 
-from .raster import Raster, RasterSequence
+from .raster import Raster
+from .raster_sequence import RasterSequence

--- a/sunraster/instr/iris/tests/test_iris_tools.py
+++ b/sunraster/instr/iris/tests/test_iris_tools.py
@@ -1,3 +1,4 @@
+"""
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
@@ -255,3 +256,4 @@ def test_calculate_dust_mask(input_array, expected_array):
 
 def test_fit_iris_xput(input_arrays, expected_array):
     np_test.assert_almost_equal(fit_iris_xput(input_arrays[0], input_arrays[1], input_arrays[2]), expected_array, decimal=6)
+"""

--- a/sunraster/instr/iris/tests/test_obsid.py
+++ b/sunraster/instr/iris/tests/test_obsid.py
@@ -1,3 +1,4 @@
+"""
 # -*- coding: utf-8 -*-
 
 import pytest
@@ -35,3 +36,4 @@ def test_attribute(attr_name, test_input, expected_output):
 def test_invalid_obsid(test_input):
     with pytest.raises(ValueError):
         ObsId(test_input)
+"""

--- a/sunraster/instr/iris/tests/test_sji.py
+++ b/sunraster/instr/iris/tests/test_sji.py
@@ -1,5 +1,6 @@
+"""
 # -*- coding: utf-8 -*-
-# """Tests for functions in sji.py"""
+# Tests for functions in sji.py
 import numpy as np
 import pytest
 from irispy import iris_tools
@@ -206,3 +207,4 @@ def test_IRISMapCubeSequence_apply_dust_mask(test_input, expected):
     test_input.apply_dust_mask(undo=True)
     for cube_test in seq_dust.data:
         np.testing.assert_array_equal(cube_test.mask, mask_dust)
+"""

--- a/sunraster/instr/iris/tests/test_spectrograph.py
+++ b/sunraster/instr/iris/tests/test_spectrograph.py
@@ -1,3 +1,4 @@
+"""
 # -*- coding: utf-8 -*-
 # Author: Daniel Ryan <ryand5@tcd.ie>
 
@@ -129,9 +130,7 @@ def iris_l2_test_raster():
 
 
 def test_fits_data_comparison(iris_l2_test_raster):
-    """
-    Make sure the data is the same in pyfits and irispy.
-    """
+    # Make sure the data is the same in pyfits and irispy.
     hdulist = fits.open(os.path.join(
         testpath, 'iris_l2_20170222_153635_3690215148_raster_t000_r00000.fits'))
     spectral_window1 = hdulist[0].header["TDESC1"]
@@ -208,3 +207,4 @@ def test_IRISSpectrogramCubeSequence_apply_exposure_time_correction(
     output_sequence = input_sequence.apply_exposure_time_correction(undo, copy=True,
                                                                     force=force)
     assert_cubesequences_equal(output_sequence, expected_sequence)
+"""

--- a/sunraster/raster.py
+++ b/sunraster/raster.py
@@ -1,17 +1,12 @@
 import textwrap
 import numbers
 
-import astropy.units as u
-import ndcube.utils.sequence
 import numpy as np
-from ndcube import NDCube, NDCubeSequence
-import ndcube.utils.cube as cube_utils
-import ndcube.utils.sequence as sequence_utils
-import ndcube.utils.wcs as wcs_utils
+import astropy.units as u
+from ndcube import NDCube
+import ndcube.utils
 
-from sunraster import utils
-
-__all__ = ['Raster', 'RasterSequence']
+__all__ = ['Raster']
 
 # Define some custom error messages.
 APPLY_EXPOSURE_TIME_ERROR = ("Exposure time correction has probably already "
@@ -46,385 +41,6 @@ SUPPORTED_EXPOSURE_NAMES = ["exposure time", "exposure_time", "exposure times",
                             "exposure_times", "exp time", "exp_time", "exp times", "exp_times"]
 SUPPORTED_EXPOSURE_NAMES += [name.upper() for name in SUPPORTED_EXPOSURE_NAMES]
 SUPPORTED_EXPOSURE_NAMES += [name.capitalize() for name in SUPPORTED_EXPOSURE_NAMES]
-
-class RasterSequence(NDCubeSequence):
-    """
-    Class for holding, slicing and plotting spectrogram data.
-
-    This class contains all the functionality of its super class with
-    some additional functionalities.
-
-    Parameters
-    ----------
-    data_list: `list`
-        List of `Raster` objects from the same spectral window and OBS ID.
-        Must also contain the 'detector type' in its meta attribute.
-
-    meta: `dict` or header object
-        Metadata associated with the sequence.
-
-    slit_step_axis: `int`
-        The axis of the Raster instances corresponding to time.
-    """
-    def __init__(self, data_list, slit_step_axis=0, meta=None):
-        # Initialize Sequence.
-        super().__init__(data_list, common_axis=slit_step_axis, meta=meta)
-        self.sequence_axis = 0
-        self._raster_axis_physical_type = self.world_axis_physical_types[self.sequence_axis]
-        self._raster_axis_name = "raster"
-        self._SnS_axis_physical_type = "time"
-        self._SnS_axis_name = "temporal"
-        self._slit_step_axis_name = "slit step"
-        self._slit_axis_name = "position along slit"
-        self._spectral_axis_name = "spectral"
-        self._raster_axes_names = np.array([self._raster_axis_name, self._slit_step_axis_name,
-                                            self._slit_axis_name, self._spectral_axis_name])
-        self._SnS_axes_names = np.array([self._SnS_axis_name, self._slit_axis_name,
-                                         self._spectral_axis_name])
-
-    raster_dimensions = NDCubeSequence.dimensions
-    SnS_dimensions = NDCubeSequence.cube_like_dimensions
-    raster_world_axis_physical_types = NDCubeSequence.world_axis_physical_types
-    SnS_world_axis_physical_types = NDCubeSequence.cube_like_world_axis_physical_types
-    raster_axis_extra_coords = NDCubeSequence.sequence_axis_extra_coords
-    SnS_axis_extra_coords = NDCubeSequence.common_axis_extra_coords
-    plot_as_raster = NDCubeSequence.plot
-    plot_as_SnS = NDCubeSequence.plot_as_cube
-
-    @property
-    def _raster_axis_index(self):
-        return self.sequence_axis
-
-    @property
-    def _slit_step_axis_index(self):
-        return self._common_axis + 1
-
-    @property
-    def _SnS_axis_index(self):
-        return self._common_axis
-
-    @property
-    def _slit_raster_axis_index(self):
-        slit_axis_index = self._slit_axis_index_partial(
-                self.data[0]._longitude_name, self._world_types_to_raster_axes,
-                self._slit_step_axis_index)
-
-    @property
-    def _slit_SnS_axis_index(self):
-        return self._slit_axis_index_partial(
-                self.data[0]._longitude_name, self._world_types_to_SnS_axes, self._SnS_axis_index)
-
-    def _slit_axis_index_partial(self, _physical_type_name, world_types_to_axes_func, axis_to_remove):
-        non_unique_name_error_fragment = "not unique to a physical axis type"
-        try:
-            slit_axis_index = self._axis_index_partial(self.data[0]._latitude_name,
-                                                       self._world_types_to_SnS_axes)
-        except ValueError as err1:
-            try:
-                if non_unique_name_error_fragment in err.args[0]:
-                    slit_axis_index = self._axis_index_partial(self.data[0]._longitude_name,
-                                                               self._world_types_to_SnS_axes)
-            except ValueError as err2:
-                if non_unique_name_error_fragment in err.args[0]:
-                    slit_axis_index = None
-                else:
-                    raise err2
-        if isinstance(slit_axis_index, tuple):
-            slit_axis_index = list(slit_axis_index)
-            slit_axis_index.remove(axis_to_remove)
-            if slit_axis_index:
-                return slit_axis_index[0]
-        else:
-            return slit_axis_index
-
-    def _axis_index_partial(self, _physical_type_name, world_types_to_axes_func):
-        # If _physical_type_name is None, then axis must have been sliced away.
-        if _physical_type_name:
-            physical_type, location = _physical_type_name
-            if location == "extra_coords":
-                include_extra_coords = True
-            else:
-                include_extra_coords = False
-            axes = world_types_to_axes_func(physical_type, include_extra_coords=include_extra_coords)
-            if len(axes) != 1:
-                raise TypeError(f"Unrecognized output of world_types_to_axes_func: {axes}.\n"
-                                "Must be a length 1 tuple.")
-            return axes[0]
-
-    @property
-    def _spectral_raster_axis_index(self):
-        spectral_axis_index = self._axis_index_partial(self.data[0]._spectral_name,
-                                                       self._world_types_to_raster_axes)
-        return spectral_axis_index
-
-    @property
-    def _spectral_SnS_axis_index(self):
-        spectral_axis_index = self._axis_index_partial(self.data[0]._spectral_name,
-                                                       self._world_types_to_SnS_axes)
-        return spectral_axis_index
-
-    @property
-    def raster_axes_types(self):
-        # Get array of indices for each axis.
-        axes_indices = [self._raster_axis_index, self._slit_step_axis_index,
-                        self._slit_raster_axis_index, self._spectral_raster_axis_index]
-        # Remove any Nones.  These correspond to missing axes.
-        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
-        return tuple(self._raster_axes_names[axes_indices])
-
-    @property
-    def SnS_axes_types(self):
-        axes_types = np.empty(len(self.SnS_dimensions))
-
-    def __str__(self):
-        if self.data[0]._time_name:
-            time_period = (self.data[0].time[0].value, self.data[-1].time[-1].value)
-        else:
-            time_period = None
-        if self.data[0]._longitude_name:
-            lon_range = u.Quantity([self.lon.min(), self.lon.max()])
-        else:
-            lon_range = None
-        if self.data[0]._latitude_name:
-            lat_range = u.Quantity([self.lat.min(), self.lat.max()])
-        else:
-            lat_range = None
-        if self.data[0]._spectral_name:
-            spectral_range = u.Quantity([self.spectral.min(), self.spectral.max()])
-        else:
-            spectral_range = None
-        return (textwrap.dedent(f"""\
-                RasterSequence
-                --------------
-                Time Range: {time_period}
-                Pixel Dimensions (raster scans, slit steps, slit height, spectral): {self.dimensions}
-                Longitude range: {lon_range}
-                Latitude range: {lat_range}
-                Spectral range: {spectral_range}
-                Data unit: {self.data[0].unit}"""))
-
-    @property
-    def slice_as_SnS(self):
-        """
-        Method to slice instance as though data were taken as a sit-and-stare,
-        i.e. slit position and raster number are combined into a single axis.
-        """
-        return _SnSSlicer(self)
-
-    @property
-    def slice_as_raster(self):
-        """
-        Method to slice instance as though data were 4D, i.e. raster number,
-        slit step position, position along slit, wavelength.
-        """
-        return _SequenceSlicer(self)
-
-    @property
-    def spectral(self):
-        return u.Quantity([raster.spectral for raster in self.data])
-
-    @property
-    def time(self):
-        return np.concatenate([raster.time for raster in self.data])
-
-    @property
-    def exposure_time(self):
-        return np.concatenate([raster.exposure_time for raster in self.data])
-
-    @property
-    def lon(self):
-        return u.Quantity([raster.lon for raster in self.data])
-
-    @property
-    def lat(self):
-        return u.Quantity([raster.lat for raster in self.data])
-
-    def apply_exposure_time_correction(self, undo=False, copy=False, force=False):
-        """
-        Applies or undoes exposure time correction to data and uncertainty and
-        adjusts unit.
-
-        Correction is only applied (undone) if the object's unit doesn't (does)
-        already include inverse time.  This can be overridden so that correction
-        is applied (undone) regardless of unit by setting force=True.
-
-        Parameters
-        ----------
-        undo: `bool`
-            If False, exposure time correction is applied.
-            If True, exposure time correction is removed.
-            Default=False
-
-        copy: `bool`
-            If True a new instance with the converted data values is returned.
-            If False, the current instance is overwritten.
-            Default=False
-
-        force: `bool`
-            If not True, applies (undoes) exposure time correction only if unit
-            doesn't (does) already include inverse time.
-            If True, correction is applied (undone) regardless of unit.  Unit is still
-            adjusted accordingly.
-
-        Returns
-        -------
-        result: `None` or `RasterSequence`
-            If copy=False, the original RasterSequence is modified with the
-            exposure time correction applied (undone).
-            If copy=True, a new RasterSequence is returned with the correction
-            applied (undone).
-        """
-        converted_data_list = []
-        for cube in self.data:
-            converted_data_list.append(cube.apply_exposure_time_correction(undo=undo,
-                                                                           force=force))
-        if copy is True:
-            return RasterSequence(
-                converted_data_list, meta=self.meta, common_axis=self._common_axis)
-        else:
-            self.data = converted_data_list
-
-    def _raster_axes_to_world_types(self, *axes, include_extra_coords=True):
-        """
-        Retrieve the world axis physical types for each pixel axis given in raster format.
-
-        This differs from world_axis_physical_types in that it provides an explicit
-        mapping between pixel axes and physical types, including dependent physical
-        types.
-
-        Parameters
-        ----------
-        axes: `int` or multiple `int`
-            Axis number in numpy ordering of axes for which real world physical types
-            are desired.
-            axes=None implies axis names for all axes will be returned.
-
-        include_extra_coords: `bool`
-           If True, also search extra_coords for coordinate corresponding to axes.
-           Default=True.
-
-        Returns
-        -------
-        axes_names: `tuple` of `str`
-            The world axis physical types corresponding to each axis.
-            If more than one physical type found for an axis, that axis's entry will
-            be a tuple of `str`.
-        """
-        # Parse user input.
-        if axes == ():
-            axes = np.arange(len(self.dimensions))
-        elif isinstance(axes, int):
-            axes = np.array([axes])
-        else:
-            axes = np.array(axes)
-
-        n_axes = len(axes)
-        axes_names = [None] * n_axes
-
-        # If sequence axis in axes, get names for it separately.
-        if self._raster_axis in axes:
-            raster_names_indices = np.array([axis == self._raster_axis for axis in axes])
-            # Get standard sequence axis name from world_axis_physical_types.
-            raster_axis_names = [self._raster_axis_physical_type]
-            # If desired, get extra coord sequence axis names.
-            if include_extra_coords:
-                extra_sequence_names = utils.sequence._get_axis_extra_coord_names_and_units(
-                        self.data, None)[0]
-                if extra_sequence_names:
-                    raster_axis_names += list(extra_sequence_names)
-            # Enter sequence axis names into output.
-            # Must use for loop as can't assign tuples to multiple array location
-            # with indexing and setitem.
-            for i in np.arange(n_axes)[raster_names_indices]:
-                axes_names[i] = tuple(raster_axis_names)
-
-            # Get indices of axes numbers associated with cube axes.
-            cube_indices = np.invert(raster_names_indices)
-            cube_axes = axes[cube_indices] - 1
-        else:
-            cube_indices = np.ones(n_axes, dtype=bool)
-            cube_axes = axes
-
-        # Get world types from cube axes.
-        if len(cube_axes) > 0:
-            cube_axes_names = self.data[0]._pixel_axes_to_world_types(
-                    *cube_axes, include_extra_coords=include_extra_coords)
-            for i, name in zip(np.arange(n_axes)[cube_indices], cube_axes_names):
-                axes_names[i] = name
-
-        return tuple(axes_names)
-
-    def _SnS_axes_to_world_types(self, *axes, include_extra_coords=True):
-        return self.data[0]._pixel_axes_to_world_types(
-                *axes, include_extra_coords=include_extra_coords)
-
-    def _world_types_to_raster_axes(self, *axes_names, include_extra_coords=True):
-        """
-        Retrieve the pixel axes (numpy ordering) corresponding to each world axis physical type.
-
-        Parameters
-        ----------
-        axes_names: `str` or multiple `str`
-            world axis physical types for which the pixel axis numbers are desired.
-            axes_names=None implies all axes will be returned.
-
-        include_extra_coords: `bool`
-           If True, also search extra_coords for axis name.
-           Default=True.
-
-        Returns
-        -------
-        axes: `tuple` of `int`
-            The pixel axis numbers (numpy ordering) that correspond to the supplied
-            axis names.
-            If more than one axis corresponds to the physical type, that physical type's
-            entry in the output will be a tuple of `int`.
-            If no axes names supplied, the ordering of the axis numbers returned will
-            correspond to the physical types returned by NDCube.world_axis_physical_types.
-        """
-        # Parse user input.
-        if axes_names == ():
-            axes_names = np.array(self.world_axis_physical_types)
-        elif isinstance(axes_names, str):
-            axes_names = np.array([axes_names])
-        else:
-            axes_names = np.array(axes_names)
-        n_names = len(axes_names)
-        axes = np.array([None] * n_names, dtype=object)
-
-        # Get world types associated with sequence axis.
-        raster_axis_names = [self._raster_axis_physical_type]
-        # If desired, also get extra coord sequence axis names.
-        if include_extra_coords:
-            extra_sequence_names = sequence_utils._get_axis_extra_coord_names_and_units(self.data, None)[0]
-            if extra_sequence_names is not None:
-                raster_axis_names += list(extra_sequence_names)
-        raster_axis_names = np.asarray(raster_axis_names)
-        # Find indices of axes_names that correspond to sequence axis and
-        # and enter axis number to output
-        raster_names_indices = np.isin(axes_names, raster_axis_names)
-        axes[raster_names_indices] = self._raster_axis_index
-
-        # Get indices of cube axis names and use Raster version of this method to get axis numbers.
-        cube_names_indices = np.invert(raster_names_indices)
-        if cube_names_indices.any():
-            # Get axes from cube.
-            cube_axes = self.data[0]._world_types_to_pixel_axes(
-                    *axes_names, include_extra_coords=include_extra_coords)
-            # Must use loop as can't use array indexing to enter >1 tuples
-            # into single array elements.
-            for i in np.arange(len(cube_names_indices))[cube_names_indices]:
-                if isinstance(cube_axes[i], tuple):
-                   this_axis_indices = tuple(np.array(cube_axes[i]) + 1)
-                else:
-                    this_axis_indices = cube_axes[i] + 1
-                axes[i] = this_axis_indices
-
-        return tuple(axes)
-
-    def _world_types_to_SnS_axes(self, *axes_names, include_extra_coords=True):
-        return self.data[0]._world_types_to_pixel_axes(
-                *axes_names, include_extra_coords=include_extra_coords)
 
 
 class Raster(NDCube):
@@ -517,7 +133,7 @@ class Raster(NDCube):
         if result.extra_coords is None:
             extra_coords = None
         else:
-            extra_coords = cube_utils.convert_extra_coords_dict_to_input_format(
+            extra_coords = ndcube.utils.cube.convert_extra_coords_dict_to_input_format(
                     result.extra_coords, result.missing_axes)
         return self.__class__(result.data, result.wcs, extra_coords, result.unit,
                               result.uncertainty, result.meta, mask=result.mask,
@@ -614,7 +230,7 @@ class Raster(NDCube):
         # Return new instance of Raster with correction applied/undone.
         return Raster(
             new_data_arrays[0], self.wcs,
-            cube_utils.convert_extra_coords_dict_to_input_format(self.extra_coords,
+            ndcube.utils.cube.convert_extra_coords_dict_to_input_format(self.extra_coords,
                                                                  self.missing_axes),
             new_unit, new_data_arrays[1], self.meta, mask=self.mask, missing_axes=self.missing_axes)
 
@@ -736,11 +352,11 @@ class Raster(NDCube):
 
             # Check WCS an extra coords for physical type.
             try:
-                axis = cube_utils.get_axis_number_from_axis_name(name, wcs_names)
+                axis = ndcube.utils.cube.get_axis_number_from_axis_name(name, wcs_names)
                 name_in_wcs = True
                 # Determine any dependent axes.
-                dependent_axes = wcs_utils.get_dependent_data_axes(self.wcs, axis,
-                                                                   self.missing_axes)
+                dependent_axes = ndcube.utils.wcs.get_dependent_data_axes(self.wcs, axis,
+                                                                          self.missing_axes)
             except ValueError as err:
                 raise err
                 name_in_wcs = False
@@ -866,28 +482,3 @@ def _uncalculate_exposure_time_correction(old_data_arrays, old_unit,
         new_data_arrays = [old_data * exposure_time for old_data in old_data_arrays]
         new_unit = old_unit*u.s
     return new_data_arrays, new_unit
-
-
-class _SnSSlicer:
-    """
-    Helper class to make slicing in index_as_cube sliceable/indexable like a
-    numpy array.
-    Parameters
-    ----------
-    seq : `ndcube.NDCubeSequence`
-        Object of NDCubeSequence.
-    """
-
-    def __init__(self, seq):
-        self.seq = seq
-
-    def __getitem__(self, item):
-        return utils.sequence._slice_sequence_as_SnS(self.seq, item)
-
-
-class _SequenceSlicer:
-    def __init__(self, seq):
-        self.seq = seq
-
-    def __getitem__(self, item):
-        return ndcube.utils.sequence.slice_sequence(self.seq, item)

--- a/sunraster/raster_sequence.py
+++ b/sunraster/raster_sequence.py
@@ -23,13 +23,14 @@ class RasterSequence(NDCubeSequence):
         List of `Raster` objects from the same spectral window and OBS ID.
         Must also contain the 'detector type' in its meta attribute.
 
-    meta: `dict` or header object
+    common_axis: `int` or `None`
+        The axis of the Raster instances corresponding to the slit step/time.
+
+    meta: `dict` or header object (optional)
         Metadata associated with the sequence.
 
-    common_axis: `int`
-        The axis of the Raster instances corresponding to the slit step/time.
     """
-    def __init__(self, data_list, common_axis=0, meta=None):
+    def __init__(self, data_list, common_axis, meta=None):
         # Initialize Sequence.
         super().__init__(data_list, common_axis=common_axis, meta=meta)
         self.sequence_axis = 0

--- a/sunraster/raster_sequence.py
+++ b/sunraster/raster_sequence.py
@@ -1,0 +1,413 @@
+import textwrap
+
+import numpy as np
+from ndcube import NDCubeSequence
+import ndcube.utils.sequence
+
+import sunraster.utils
+
+__all__ = ['RasterSequence']
+
+
+class RasterSequence(NDCubeSequence):
+    """
+    Class for holding, slicing and plotting spectrogram data.
+
+    This class contains all the functionality of its super class with
+    some additional functionalities.
+
+    Parameters
+    ----------
+    data_list: `list`
+        List of `Raster` objects from the same spectral window and OBS ID.
+        Must also contain the 'detector type' in its meta attribute.
+
+    meta: `dict` or header object
+        Metadata associated with the sequence.
+
+    slit_step_axis: `int`
+        The axis of the Raster instances corresponding to time.
+    """
+    def __init__(self, data_list, slit_step_axis=0, meta=None):
+        # Initialize Sequence.
+        super().__init__(data_list, common_axis=slit_step_axis, meta=meta)
+        self.sequence_axis = 0
+        self._raster_axis_physical_type = self.world_axis_physical_types[self.sequence_axis]
+        self._raster_axis_name = "raster"
+        self._SnS_axis_physical_type = "time"
+        self._SnS_axis_name = "temporal"
+        self._slit_step_axis_name = "slit step"
+        self._slit_axis_name = "position along slit"
+        self._spectral_axis_name = "spectral"
+        self._raster_axes_names = np.array([self._raster_axis_name, self._slit_step_axis_name,
+                                            self._slit_axis_name, self._spectral_axis_name])
+        self._SnS_axes_names = np.array([self._SnS_axis_name, self._slit_axis_name,
+                                         self._spectral_axis_name])
+
+    raster_dimensions = NDCubeSequence.dimensions
+    SnS_dimensions = NDCubeSequence.cube_like_dimensions
+    raster_world_axis_physical_types = NDCubeSequence.world_axis_physical_types
+    SnS_world_axis_physical_types = NDCubeSequence.cube_like_world_axis_physical_types
+    raster_axis_extra_coords = NDCubeSequence.sequence_axis_extra_coords
+    SnS_axis_extra_coords = NDCubeSequence.common_axis_extra_coords
+    plot_as_raster = NDCubeSequence.plot
+    plot_as_SnS = NDCubeSequence.plot_as_cube
+
+    @property
+    def _raster_axis_index(self):
+        return self.sequence_axis
+
+    @property
+    def _slit_step_axis_index(self):
+        return self._common_axis + 1
+
+    @property
+    def _SnS_axis_index(self):
+        return self._common_axis
+
+    @property
+    def _slit_raster_axis_index(self):
+        slit_axis_index = self._slit_axis_index_partial(
+                self.data[0]._longitude_name, self._world_types_to_raster_axes,
+                self._slit_step_axis_index)
+
+    @property
+    def _slit_SnS_axis_index(self):
+        return self._slit_axis_index_partial(
+                self.data[0]._longitude_name, self._world_types_to_SnS_axes, self._SnS_axis_index)
+
+    def _slit_axis_index_partial(self, _physical_type_name, world_types_to_axes_func, axis_to_remove):
+        non_unique_name_error_fragment = "not unique to a physical axis type"
+        try:
+            slit_axis_index = self._axis_index_partial(self.data[0]._latitude_name,
+                                                       self._world_types_to_SnS_axes)
+        except ValueError as err1:
+            try:
+                if non_unique_name_error_fragment in err.args[0]:
+                    slit_axis_index = self._axis_index_partial(self.data[0]._longitude_name,
+                                                               self._world_types_to_SnS_axes)
+            except ValueError as err2:
+                if non_unique_name_error_fragment in err.args[0]:
+                    slit_axis_index = None
+                else:
+                    raise err2
+        if isinstance(slit_axis_index, tuple):
+            slit_axis_index = list(slit_axis_index)
+            slit_axis_index.remove(axis_to_remove)
+            if slit_axis_index:
+                return slit_axis_index[0]
+        else:
+            return slit_axis_index
+
+    def _axis_index_partial(self, _physical_type_name, world_types_to_axes_func):
+        # If _physical_type_name is None, then axis must have been sliced away.
+        if _physical_type_name:
+            physical_type, location = _physical_type_name
+            if location == "extra_coords":
+                include_extra_coords = True
+            else:
+                include_extra_coords = False
+            axes = world_types_to_axes_func(physical_type, include_extra_coords=include_extra_coords)
+            if len(axes) != 1:
+                raise TypeError(f"Unrecognized output of world_types_to_axes_func: {axes}.\n"
+                                "Must be a length 1 tuple.")
+            return axes[0]
+
+    @property
+    def _spectral_raster_axis_index(self):
+        spectral_axis_index = self._axis_index_partial(self.data[0]._spectral_name,
+                                                       self._world_types_to_raster_axes)
+        return spectral_axis_index
+
+    @property
+    def _spectral_SnS_axis_index(self):
+        spectral_axis_index = self._axis_index_partial(self.data[0]._spectral_name,
+                                                       self._world_types_to_SnS_axes)
+        return spectral_axis_index
+
+    @property
+    def raster_axes_types(self):
+        # Get array of indices for each axis.
+        axes_indices = [self._raster_axis_index, self._slit_step_axis_index,
+                        self._slit_raster_axis_index, self._spectral_raster_axis_index]
+        # Remove any Nones.  These correspond to missing axes.
+        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
+        return tuple(self._raster_axes_names[axes_indices])
+
+    @property
+    def SnS_axes_types(self):
+        axes_types = np.empty(len(self.SnS_dimensions))
+
+    def __str__(self):
+        if self.data[0]._time_name:
+            time_period = (self.data[0].time[0].value, self.data[-1].time[-1].value)
+        else:
+            time_period = None
+        if self.data[0]._longitude_name:
+            lon_range = u.Quantity([self.lon.min(), self.lon.max()])
+        else:
+            lon_range = None
+        if self.data[0]._latitude_name:
+            lat_range = u.Quantity([self.lat.min(), self.lat.max()])
+        else:
+            lat_range = None
+        if self.data[0]._spectral_name:
+            spectral_range = u.Quantity([self.spectral.min(), self.spectral.max()])
+        else:
+            spectral_range = None
+        return (textwrap.dedent(f"""\
+                RasterSequence
+                --------------
+                Time Range: {time_period}
+                Pixel Dimensions (raster scans, slit steps, slit height, spectral): {self.dimensions}
+                Longitude range: {lon_range}
+                Latitude range: {lat_range}
+                Spectral range: {spectral_range}
+                Data unit: {self.data[0].unit}"""))
+    @property
+    def slice_as_SnS(self):
+        """
+        Method to slice instance as though data were taken as a sit-and-stare,
+        i.e. slit position and raster number are combined into a single axis.
+        """
+        return _SnSSlicer(self)
+
+    @property
+    def slice_as_raster(self):
+        """
+        Method to slice instance as though data were 4D, i.e. raster number,
+        slit step position, position along slit, wavelength.
+        """
+        return _SequenceSlicer(self)
+
+    @property
+    def spectral(self):
+        return u.Quantity([raster.spectral for raster in self.data])
+
+    @property
+    def time(self):
+        return np.concatenate([raster.time for raster in self.data])
+
+    @property
+    def exposure_time(self):
+        return np.concatenate([raster.exposure_time for raster in self.data])
+
+    @property
+    def lon(self):
+        return u.Quantity([raster.lon for raster in self.data])
+
+    @property
+    def lat(self):
+        return u.Quantity([raster.lat for raster in self.data])
+
+    def apply_exposure_time_correction(self, undo=False, copy=False, force=False):
+        """
+        Applies or undoes exposure time correction to data and uncertainty and
+        adjusts unit.
+
+        Correction is only applied (undone) if the object's unit doesn't (does)
+        already include inverse time.  This can be overridden so that correction
+        is applied (undone) regardless of unit by setting force=True.
+
+        Parameters
+        ----------
+        undo: `bool`
+            If False, exposure time correction is applied.
+            If True, exposure time correction is removed.
+            Default=False
+
+        copy: `bool`
+            If True a new instance with the converted data values is returned.
+            If False, the current instance is overwritten.
+            Default=False
+
+        force: `bool`
+            If not True, applies (undoes) exposure time correction only if unit
+            doesn't (does) already include inverse time.
+            If True, correction is applied (undone) regardless of unit.  Unit is still
+            adjusted accordingly.
+
+        Returns
+        -------
+        result: `None` or `RasterSequence`
+            If copy=False, the original RasterSequence is modified with the
+            exposure time correction applied (undone).
+            If copy=True, a new RasterSequence is returned with the correction
+            applied (undone).
+        """
+        converted_data_list = []
+        for cube in self.data:
+            converted_data_list.append(cube.apply_exposure_time_correction(undo=undo,
+                                                                           force=force))
+        if copy is True:
+            return RasterSequence(
+                converted_data_list, meta=self.meta, common_axis=self._common_axis)
+        else:
+            self.data = converted_data_list
+
+        def _raster_axes_to_world_types(self, *axes, include_extra_coords=True):
+        """
+        Retrieve the world axis physical types for each pixel axis given in raster format.
+
+        This differs from world_axis_physical_types in that it provides an explicit
+        mapping between pixel axes and physical types, including dependent physical
+        types.
+
+        Parameters
+        ----------
+        axes: `int` or multiple `int`
+            Axis number in numpy ordering of axes for which real world physical types
+            are desired.
+            axes=None implies axis names for all axes will be returned.
+
+        include_extra_coords: `bool`
+           If True, also search extra_coords for coordinate corresponding to axes.
+           Default=True.
+
+        Returns
+        -------
+        axes_names: `tuple` of `str`
+            The world axis physical types corresponding to each axis.
+            If more than one physical type found for an axis, that axis's entry will
+            be a tuple of `str`.
+        """
+        # Parse user input.
+        if axes == ():
+            axes = np.arange(len(self.dimensions))
+        elif isinstance(axes, int):
+            axes = np.array([axes])
+        else:
+            axes = np.array(axes)
+
+        n_axes = len(axes)
+        axes_names = [None] * n_axes
+
+        # If sequence axis in axes, get names for it separately.
+        if self._raster_axis_index in axes:
+            raster_names_indices = np.array([axis == self._raster_axis for axis in axes])
+            # Get standard sequence axis name from world_axis_physical_types.
+            raster_axis_names = [self._raster_axis_physical_type]
+            # If desired, get extra coord sequence axis names.
+            if include_extra_coords:
+                extra_sequence_names = ndcube.utils.sequence._get_axis_extra_coord_names_and_units(
+                        self.data, None)[0]
+                if extra_sequence_names:
+                    raster_axis_names += list(extra_sequence_names)
+            # Enter sequence axis names into output.
+            # Must use for loop as can't assign tuples to multiple array location
+            # with indexing and setitem.
+            for i in np.arange(n_axes)[raster_names_indices]:
+                axes_names[i] = tuple(raster_axis_names)
+
+            # Get indices of axes numbers associated with cube axes.
+            cube_indices = np.invert(raster_names_indices)
+            cube_axes = axes[cube_indices] - 1
+        else:
+            cube_indices = np.ones(n_axes, dtype=bool)
+            cube_axes = axes
+
+        # Get world types from cube axes.
+        if len(cube_axes) > 0:
+            cube_axes_names = self.data[0]._pixel_axes_to_world_types(
+                    *cube_axes, include_extra_coords=include_extra_coords)
+            for i, name in zip(np.arange(n_axes)[cube_indices], cube_axes_names):
+                axes_names[i] = name
+
+        return tuple(axes_names)
+
+    def _SnS_axes_to_world_types(self, *axes, include_extra_coords=True):
+        return self.data[0]._pixel_axes_to_world_types(
+                *axes, include_extra_coords=include_extra_coords)
+
+    def _world_types_to_raster_axes(self, *axes_names, include_extra_coords=True):
+        """
+        Retrieve the pixel axes (numpy ordering) corresponding to each world axis physical type.
+
+        Parameters
+        ----------
+        axes_names: `str` or multiple `str`
+            world axis physical types for which the pixel axis numbers are desired.
+            axes_names=None implies all axes will be returned.
+
+        include_extra_coords: `bool`
+           If True, also search extra_coords for axis name.
+           Default=True.
+
+        Returns
+        -------
+        axes: `tuple` of `int`
+            The pixel axis numbers (numpy ordering) that correspond to the supplied
+            axis names.
+            If more than one axis corresponds to the physical type, that physical type's
+            entry in the output will be a tuple of `int`.
+            If no axes names supplied, the ordering of the axis numbers returned will
+            correspond to the physical types returned by NDCube.world_axis_physical_types.
+        """
+        # Parse user input.
+        if axes_names == ():
+            axes_names = np.array(self.world_axis_physical_types)
+        elif isinstance(axes_names, str):
+            axes_names = np.array([axes_names])
+        else:
+            axes_names = np.array(axes_names)
+        n_names = len(axes_names)
+        axes = np.array([None] * n_names, dtype=object)
+
+        # Get world types associated with sequence axis.
+        raster_axis_names = [self._raster_axis_physical_type]
+        # If desired, also get extra coord sequence axis names.
+        if include_extra_coords:
+            extra_sequence_names = ndcube.utils.sequence._get_axis_extra_coord_names_and_units(self.data, None)[0]
+            if extra_sequence_names is not None:
+                raster_axis_names += list(extra_sequence_names)
+        raster_axis_names = np.asarray(raster_axis_names)
+        # Find indices of axes_names that correspond to sequence axis and
+        # and enter axis number to output
+        raster_names_indices = np.isin(axes_names, raster_axis_names)
+        axes[raster_names_indices] = self._raster_axis_index
+
+        # Get indices of cube axis names and use Raster version of this method to get axis numbers.
+        cube_names_indices = np.invert(raster_names_indices)
+        if cube_names_indices.any():
+            # Get axes from cube.
+            cube_axes = self.data[0]._world_types_to_pixel_axes(
+                    *axes_names, include_extra_coords=include_extra_coords)
+            # Must use loop as can't use array indexing to enter >1 tuples
+            # into single array elements.
+            for i in np.arange(len(cube_names_indices))[cube_names_indices]:
+                if isinstance(cube_axes[i], tuple):
+                   this_axis_indices = tuple(np.array(cube_axes[i]) + 1)
+                else:
+                    this_axis_indices = cube_axes[i] + 1
+                axes[i] = this_axis_indices
+
+        return tuple(axes)
+
+    def _world_types_to_SnS_axes(self, *axes_names, include_extra_coords=True):
+        return self.data[0]._world_types_to_pixel_axes(
+                *axes_names, include_extra_coords=include_extra_coords)
+
+
+class _SnSSlicer:
+    """
+    Helper class to make slicing in index_as_cube sliceable/indexable like a
+    numpy array.
+    Parameters
+    ----------
+    seq : `ndcube.NDCubeSequence`
+        Object of NDCubeSequence.
+    """
+
+    def __init__(self, seq):
+        self.seq = seq
+
+    def __getitem__(self, item):
+        return sunraster.utils.sequence._slice_sequence_as_SnS(self.seq, item)
+
+
+class _SequenceSlicer:
+    def __init__(self, seq):
+        self.seq = seq
+
+    def __getitem__(self, item):
+        return ndcube.utils.sequence.slice_sequence(self.seq, item)

--- a/sunraster/raster_sequence.py
+++ b/sunraster/raster_sequence.py
@@ -155,30 +155,50 @@ class RasterSequence(NDCubeSequence):
 
     def __str__(self):
         if self.data[0]._time_name:
-            time_period = (self.data[0].time[0].value, self.data[-1].time[-1].value)
+            times = self.data[0].time
+            if times.isscalar:
+                time_period = times.value
+            else:
+                time_period = (times[0].value, times[-1].value)
         else:
             time_period = None
         if self.data[0]._longitude_name:
-            lon_range = u.Quantity([self.lon.min(), self.lon.max()])
+            lon = self.lon
+            if lon.isscalar:
+                lon_range = lon
+            else:
+                lon_range = u.Quantity([lon.min(), lon.max()])
         else:
             lon_range = None
         if self.data[0]._latitude_name:
-            lat_range = u.Quantity([self.lat.min(), self.lat.max()])
+            lat = self.lat
+            if lat.isscalar:
+                lat_range = self.lat
+            else:
+                lat_range = u.Quantity([lat.min(), lat.max()])
         else:
             lat_range = None
         if self.data[0]._spectral_name:
-            spectral_range = u.Quantity([self.spectral.min(), self.spectral.max()])
+            spectral = self.spectral
+            if spectral.isscalar:
+                spectral_range = spectral
+            else:
+                spectral_range = u.Quantity([spectral.min(), spectral.max()])
         else:
             spectral_range = None
         return (textwrap.dedent(f"""\
                 RasterSequence
                 --------------
                 Time Range: {time_period}
-                Pixel Dimensions (raster scans, slit steps, slit height, spectral): {self.dimensions}
+                Axes Types: {self.raster_axes_types}
+                Axes Dimensions: {self.dimensions}
                 Longitude range: {lon_range}
                 Latitude range: {lat_range}
                 Spectral range: {spectral_range}
                 Data unit: {self.data[0].unit}"""))
+
+    def __repr__(self):
+        return f"{object.__repr__(self)}\n{str(self)}"
 
     @property
     def _raster_axis_index(self):

--- a/sunraster/raster_sequence.py
+++ b/sunraster/raster_sequence.py
@@ -55,6 +55,132 @@ class RasterSequence(NDCubeSequence):
     plot_as_SnS = NDCubeSequence.plot_as_cube
 
     @property
+    def spectral(self):
+        return u.Quantity([raster.spectral for raster in self.data])
+
+    @property
+    def time(self):
+        return np.concatenate([raster.time for raster in self.data])
+
+    @property
+    def exposure_time(self):
+        return np.concatenate([raster.exposure_time for raster in self.data])
+
+    @property
+    def lon(self):
+        return u.Quantity([raster.lon for raster in self.data])
+
+    @property
+    def lat(self):
+        return u.Quantity([raster.lat for raster in self.data])
+
+    @property
+    def raster_axes_types(self):
+        # Get array of indices for each axis.
+        axes_indices = [self._raster_axis_index, self._slit_step_axis_index,
+                        self._slit_axis_raster_index, self._spectral_axis_raster_index]
+        # Remove any Nones.  These correspond to missing axes.
+        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
+        return tuple(self._raster_axes_names[axes_indices])
+
+    @property
+    def SnS_axes_types(self):
+        # Get array of indices for each axis.
+        axes_indices = [self._SnS_axis_index, self._slit_axis_SnS_index,
+                        self._spectral_axis_SnS_index]
+        # Remove any Nones.  These correspond to missing axes.
+        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
+        return tuple(self._SnS_axes_names[axes_indices])
+
+    @property
+    def slice_as_SnS(self):
+        """
+        Method to slice instance as though data were taken as a sit-and-stare,
+        i.e. slit position and raster number are combined into a single axis.
+        """
+        return _SnSSlicer(self)
+
+    @property
+    def slice_as_raster(self):
+        """
+        Method to slice instance as though data were 4D, i.e. raster number,
+        slit step position, position along slit, wavelength.
+        """
+        return _SequenceSlicer(self)
+
+    def apply_exposure_time_correction(self, undo=False, copy=False, force=False):
+        """
+        Applies or undoes exposure time correction to data and uncertainty and
+        adjusts unit.
+
+        Correction is only applied (undone) if the object's unit doesn't (does)
+        already include inverse time.  This can be overridden so that correction
+        is applied (undone) regardless of unit by setting force=True.
+
+        Parameters
+        ----------
+        undo: `bool`
+            If False, exposure time correction is applied.
+            If True, exposure time correction is removed.
+            Default=False
+
+        copy: `bool`
+            If True a new instance with the converted data values is returned.
+            If False, the current instance is overwritten.
+            Default=False
+
+        force: `bool`
+            If not True, applies (undoes) exposure time correction only if unit
+            doesn't (does) already include inverse time.
+            If True, correction is applied (undone) regardless of unit.  Unit is still
+            adjusted accordingly.
+
+        Returns
+        -------
+        result: `None` or `RasterSequence`
+            If copy=False, the original RasterSequence is modified with the
+            exposure time correction applied (undone).
+            If copy=True, a new RasterSequence is returned with the correction
+            applied (undone).
+        """
+        converted_data_list = []
+        for cube in self.data:
+            converted_data_list.append(cube.apply_exposure_time_correction(undo=undo,
+                                                                           force=force))
+        if copy is True:
+            return RasterSequence(
+                converted_data_list, meta=self.meta, common_axis=self._SnS_axis_index)
+        else:
+            self.data = converted_data_list
+
+    def __str__(self):
+        if self.data[0]._time_name:
+            time_period = (self.data[0].time[0].value, self.data[-1].time[-1].value)
+        else:
+            time_period = None
+        if self.data[0]._longitude_name:
+            lon_range = u.Quantity([self.lon.min(), self.lon.max()])
+        else:
+            lon_range = None
+        if self.data[0]._latitude_name:
+            lat_range = u.Quantity([self.lat.min(), self.lat.max()])
+        else:
+            lat_range = None
+        if self.data[0]._spectral_name:
+            spectral_range = u.Quantity([self.spectral.min(), self.spectral.max()])
+        else:
+            spectral_range = None
+        return (textwrap.dedent(f"""\
+                RasterSequence
+                --------------
+                Time Range: {time_period}
+                Pixel Dimensions (raster scans, slit steps, slit height, spectral): {self.dimensions}
+                Longitude range: {lon_range}
+                Latitude range: {lat_range}
+                Spectral range: {spectral_range}
+                Data unit: {self.data[0].unit}"""))
+
+    @property
     def _raster_axis_index(self):
         return self.sequence_axis
 
@@ -136,132 +262,6 @@ class RasterSequence(NDCubeSequence):
                 raise TypeError(f"Unrecognized output of world_types_to_axes_func: {axes}.\n"
                                 "Must be a length 1 tuple.")
             return axes[0]
-
-    @property
-    def raster_axes_types(self):
-        # Get array of indices for each axis.
-        axes_indices = [self._raster_axis_index, self._slit_step_axis_index,
-                        self._slit_axis_raster_index, self._spectral_axis_raster_index]
-        # Remove any Nones.  These correspond to missing axes.
-        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
-        return tuple(self._raster_axes_names[axes_indices])
-
-    @property
-    def SnS_axes_types(self):
-        # Get array of indices for each axis.
-        axes_indices = [self._SnS_axis_index, self._slit_axis_SnS_index,
-                        self._spectral_axis_SnS_index]
-        # Remove any Nones.  These correspond to missing axes.
-        axes_indices = np.array(list(filter((None).__ne__, axes_indices)))
-        return tuple(self._SnS_axes_names[axes_indices])
-
-    def __str__(self):
-        if self.data[0]._time_name:
-            time_period = (self.data[0].time[0].value, self.data[-1].time[-1].value)
-        else:
-            time_period = None
-        if self.data[0]._longitude_name:
-            lon_range = u.Quantity([self.lon.min(), self.lon.max()])
-        else:
-            lon_range = None
-        if self.data[0]._latitude_name:
-            lat_range = u.Quantity([self.lat.min(), self.lat.max()])
-        else:
-            lat_range = None
-        if self.data[0]._spectral_name:
-            spectral_range = u.Quantity([self.spectral.min(), self.spectral.max()])
-        else:
-            spectral_range = None
-        return (textwrap.dedent(f"""\
-                RasterSequence
-                --------------
-                Time Range: {time_period}
-                Pixel Dimensions (raster scans, slit steps, slit height, spectral): {self.dimensions}
-                Longitude range: {lon_range}
-                Latitude range: {lat_range}
-                Spectral range: {spectral_range}
-                Data unit: {self.data[0].unit}"""))
-
-    @property
-    def slice_as_SnS(self):
-        """
-        Method to slice instance as though data were taken as a sit-and-stare,
-        i.e. slit position and raster number are combined into a single axis.
-        """
-        return _SnSSlicer(self)
-
-    @property
-    def slice_as_raster(self):
-        """
-        Method to slice instance as though data were 4D, i.e. raster number,
-        slit step position, position along slit, wavelength.
-        """
-        return _SequenceSlicer(self)
-
-    @property
-    def spectral(self):
-        return u.Quantity([raster.spectral for raster in self.data])
-
-    @property
-    def time(self):
-        return np.concatenate([raster.time for raster in self.data])
-
-    @property
-    def exposure_time(self):
-        return np.concatenate([raster.exposure_time for raster in self.data])
-
-    @property
-    def lon(self):
-        return u.Quantity([raster.lon for raster in self.data])
-
-    @property
-    def lat(self):
-        return u.Quantity([raster.lat for raster in self.data])
-
-    def apply_exposure_time_correction(self, undo=False, copy=False, force=False):
-        """
-        Applies or undoes exposure time correction to data and uncertainty and
-        adjusts unit.
-
-        Correction is only applied (undone) if the object's unit doesn't (does)
-        already include inverse time.  This can be overridden so that correction
-        is applied (undone) regardless of unit by setting force=True.
-
-        Parameters
-        ----------
-        undo: `bool`
-            If False, exposure time correction is applied.
-            If True, exposure time correction is removed.
-            Default=False
-
-        copy: `bool`
-            If True a new instance with the converted data values is returned.
-            If False, the current instance is overwritten.
-            Default=False
-
-        force: `bool`
-            If not True, applies (undoes) exposure time correction only if unit
-            doesn't (does) already include inverse time.
-            If True, correction is applied (undone) regardless of unit.  Unit is still
-            adjusted accordingly.
-
-        Returns
-        -------
-        result: `None` or `RasterSequence`
-            If copy=False, the original RasterSequence is modified with the
-            exposure time correction applied (undone).
-            If copy=True, a new RasterSequence is returned with the correction
-            applied (undone).
-        """
-        converted_data_list = []
-        for cube in self.data:
-            converted_data_list.append(cube.apply_exposure_time_correction(undo=undo,
-                                                                           force=force))
-        if copy is True:
-            return RasterSequence(
-                converted_data_list, meta=self.meta, common_axis=self._SnS_axis_index)
-        else:
-            self.data = converted_data_list
 
     def _raster_axes_to_world_types(self, *axes, include_extra_coords=True):
         """

--- a/sunraster/tests/test_raster.py
+++ b/sunraster/tests/test_raster.py
@@ -69,6 +69,6 @@ spectrogram_DN_s1 = Raster(
     (spectrogram_DN_per_s0, False, True, spectrogram_DN_per_s_per_s0),
     (spectrogram_DN0, True, True, spectrogram_DN_s0)
 ])
-def test__apply_exposure_time_correction(input_cube, undo, force, expected_cube):
+def test_apply_exposure_time_correction(input_cube, undo, force, expected_cube):
     output_cube = input_cube.apply_exposure_time_correction(undo=undo, force=force)
     assert_cubes_equal(output_cube, expected_cube)

--- a/sunraster/tests/test_raster.py
+++ b/sunraster/tests/test_raster.py
@@ -1,15 +1,15 @@
 
 import numpy as np
 import pytest
-from ndcube.tests.helpers import assert_cubes_equal, assert_cubesequences_equal
+from ndcube.tests.helpers import assert_cubes_equal
 from ndcube.utils.wcs import WCS
 
 import astropy.units as u
 from astropy.time import Time, TimeDelta
 
-from sunraster.raster import Raster, RasterSequence
+from sunraster.raster import Raster
 
-# Define an sample wcs object
+# Define a sample wcs object
 h0 = {
     'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10,
     'NAXIS1': 3,
@@ -62,13 +62,6 @@ spectrogram_DN_s1 = Raster(
     SOURCE_DATA_DN*single_exposure_time, wcs0, extra_coords1, u.ct*u.s,
     SOURCE_UNCERTAINTY_DN*single_exposure_time)
 
-# Define RasterSequences
-sequence_DN = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq)
-sequence_DN_per_s = RasterSequence(
-        [spectrogram_DN_per_s0, spectrogram_DN_per_s1], meta=meta_seq)
-sequence_DN_per_s_per_s = RasterSequence(
-    [spectrogram_DN_per_s_per_s0, spectrogram_DN_per_s_per_s1], meta=meta_seq)
-sequence_DN_s = RasterSequence([spectrogram_DN_s0, spectrogram_DN_s1], meta=meta_seq)
 
 @pytest.mark.parametrize("input_cube, undo, force, expected_cube", [
     (spectrogram_DN0, False, False, spectrogram_DN_per_s0),
@@ -76,20 +69,6 @@ sequence_DN_s = RasterSequence([spectrogram_DN_s0, spectrogram_DN_s1], meta=meta
     (spectrogram_DN_per_s0, False, True, spectrogram_DN_per_s_per_s0),
     (spectrogram_DN0, True, True, spectrogram_DN_s0)
 ])
-def test_Raster_apply_exposure_time_correction(input_cube, undo,
-                                                            force, expected_cube):
+def test__apply_exposure_time_correction(input_cube, undo, force, expected_cube):
     output_cube = input_cube.apply_exposure_time_correction(undo=undo, force=force)
     assert_cubes_equal(output_cube, expected_cube)
-
-
-@pytest.mark.parametrize("input_sequence, undo, force, expected_sequence", [
-    (sequence_DN, False, False, sequence_DN_per_s),
-    (sequence_DN_per_s, True, False, sequence_DN),
-    (sequence_DN_per_s, False, True, sequence_DN_per_s_per_s),
-    (sequence_DN, True, True, sequence_DN_s)
-])
-def test_RasterSequence_apply_exposure_time_correction(
-        input_sequence, undo, force, expected_sequence):
-    output_sequence = input_sequence.apply_exposure_time_correction(undo, copy=True,
-                                                                    force=force)
-    assert_cubesequences_equal(output_sequence, expected_sequence)

--- a/sunraster/tests/test_rastersequence.py
+++ b/sunraster/tests/test_rastersequence.py
@@ -1,0 +1,168 @@
+
+import numpy as np
+import pytest
+from ndcube.tests.helpers import assert_cubesequences_equal
+from ndcube.utils.wcs import WCS
+
+import astropy.units as u
+from astropy.time import Time, TimeDelta
+
+from sunraster import Raster, RasterSequence
+
+# Define an sample wcs object
+h0 = {
+    'CTYPE1': 'WAVE    ', 'CUNIT1': 'Angstrom', 'CDELT1': 0.2, 'CRPIX1': 0, 'CRVAL1': 10,
+    'NAXIS1': 3,
+    'CTYPE2': 'HPLT-TAN', 'CUNIT2': 'deg', 'CDELT2': 0.5, 'CRPIX2': 2, 'CRVAL2': 0.5, 'NAXIS2': 2,
+    'CTYPE3': 'HPLN-TAN', 'CUNIT3': 'deg', 'CDELT3': 0.4, 'CRPIX3': 2, 'CRVAL3': 1, 'NAXIS3': 2,
+}
+wcs0 = WCS(header=h0, naxis=3)
+
+SOURCE_DATA_DN = np.array([[[ 0.563,  1.132, -1.343], [-0.719,  1.441, 1.566]],
+                           [[ 0.563,  1.132, -1.343], [-0.719,  1.441, 1.566]]])
+SOURCE_UNCERTAINTY_DN = np.sqrt(SOURCE_DATA_DN)
+
+time_dim_len = SOURCE_DATA_DN.shape[0]
+single_exposure_time = 2.
+EXPOSURE_TIME = u.Quantity(np.zeros(time_dim_len)+single_exposure_time, unit=u.s)
+
+# Define sample extra coords
+extra_coords0 = [("time", 0,
+                  Time('2017-01-01') + TimeDelta(np.arange(time_dim_len), format='sec')),
+                 ("exposure time", 0, EXPOSURE_TIME)]
+extra_coords1 = [("time", 0,
+                  (Time('2017-01-01') +
+                   TimeDelta(np.arange(time_dim_len, time_dim_len*2), format='sec'))),
+                 ("exposure time", 0, EXPOSURE_TIME)]
+
+# Define sample extra coords
+extra_coords0 = [("time", 0,
+                  Time('2017-01-01') + TimeDelta(np.arange(time_dim_len), format='sec')),
+                 ("exposure time", 0, EXPOSURE_TIME)]
+extra_coords1 = [("time", 0,
+                  (Time('2017-01-01') +
+                   TimeDelta(np.arange(time_dim_len, time_dim_len*2), format='sec'))),
+                 ("exposure time", 0, EXPOSURE_TIME)]
+
+# Define meta data
+meta_seq = {"a": 0}
+
+# Define RasterSequences in various units.
+spectrogram_DN0 = Raster(
+    SOURCE_DATA_DN, wcs0, extra_coords0, u.ct, SOURCE_UNCERTAINTY_DN)
+spectrogram_DN1 = Raster(
+    SOURCE_DATA_DN, wcs0, extra_coords1, u.ct, SOURCE_UNCERTAINTY_DN)
+sequence_DN = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq)
+sequence_DN0 = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq, common_axis=0)
+sequence_DN1 = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq, common_axis=1)
+sequence_DN2 = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq, common_axis=2)
+
+spectrogram_DN_per_s0 = Raster(
+    SOURCE_DATA_DN/single_exposure_time, wcs0, extra_coords0, u.ct/u.s,
+    SOURCE_UNCERTAINTY_DN/single_exposure_time)
+spectrogram_DN_per_s1 = Raster(
+    SOURCE_DATA_DN/single_exposure_time, wcs0, extra_coords1, u.ct/u.s,
+    SOURCE_UNCERTAINTY_DN/single_exposure_time)
+sequence_DN_per_s = RasterSequence(
+        [spectrogram_DN_per_s0, spectrogram_DN_per_s1], meta=meta_seq)
+
+spectrogram_DN_per_s_per_s0 = Raster(
+    SOURCE_DATA_DN/single_exposure_time/single_exposure_time, wcs0, extra_coords0, u.ct/u.s/u.s,
+    SOURCE_UNCERTAINTY_DN/single_exposure_time/single_exposure_time)
+spectrogram_DN_per_s_per_s1 = Raster(
+    SOURCE_DATA_DN/single_exposure_time/single_exposure_time, wcs0, extra_coords1, u.ct/u.s/u.s,
+    SOURCE_UNCERTAINTY_DN/single_exposure_time/single_exposure_time)
+sequence_DN_per_s_per_s = RasterSequence(
+    [spectrogram_DN_per_s_per_s0, spectrogram_DN_per_s_per_s1], meta=meta_seq)
+
+spectrogram_DN_s0 = Raster( 
+    SOURCE_DATA_DN*single_exposure_time, wcs0, extra_coords0, u.ct*u.s,
+    SOURCE_UNCERTAINTY_DN*single_exposure_time)
+spectrogram_DN_s1 = Raster(
+    SOURCE_DATA_DN*single_exposure_time, wcs0, extra_coords1, u.ct*u.s,
+    SOURCE_UNCERTAINTY_DN*single_exposure_time)
+sequence_DN_s = RasterSequence([spectrogram_DN_s0, spectrogram_DN_s1], meta=meta_seq)
+
+
+@pytest.mark.parametrize("input_sequence, undo, force, expected_sequence", [
+    (sequence_DN, False, False, sequence_DN_per_s),
+    (sequence_DN_per_s, True, False, sequence_DN),
+    (sequence_DN_per_s, False, True, sequence_DN_per_s_per_s),
+    (sequence_DN, True, True, sequence_DN_s)
+])
+def test_apply_exposure_time_correction(input_sequence, undo, force, expected_sequence):
+    output_sequence = input_sequence.apply_exposure_time_correction(undo, copy=True, force=force)
+    assert_cubesequences_equal(output_sequence, expected_sequence)
+
+
+@pytest.mark.parametrize("input_sequence, expected_slit_step_axis", [
+    (sequence_DN1, 2),
+    #(sequence_DN1[:, 0], 1), # Won't wok until NDCubeSequence._common_axis slicing bug fixed.
+    #(sequence_DN2[:, 0, 0], 1), # Won't wok until NDCubeSequence._common_axis slicing bug fixed.
+    #(sequence_DN1[:, :, 0], None), # Won't wok until NDCubeSequence._common_axis slicing bug fixed.
+    (sequence_DN1[:, :, :, 0], 2),
+])
+def test_slit_step_axis_index(input_sequence, expected_slit_step_axis):
+    assert input_sequence._slit_step_axis_index == expected_slit_step_axis
+
+
+@pytest.mark.parametrize("input_sequence, expected_slit_axis_raster_index", [
+    (sequence_DN0, 2),
+    (sequence_DN0[:, 0], 1),
+    (sequence_DN0[:, :, 0], None)
+])
+def test_slit_axis_raster_index(input_sequence, expected_slit_axis_raster_index):
+    assert input_sequence._slit_axis_raster_index == expected_slit_axis_raster_index
+
+
+@pytest.mark.parametrize("input_sequence, expected_slit_axis_SnS_index", [
+    (sequence_DN0, 1),
+    (sequence_DN0[:, 0], 0),
+    (sequence_DN0[:, :, 0], None)
+])
+def test_slit_axis_SnS_index(input_sequence, expected_slit_axis_SnS_index):
+    assert input_sequence._slit_axis_SnS_index == expected_slit_axis_SnS_index
+
+
+@pytest.mark.parametrize("input_sequence, expected_spectral_axis_raster_index", [
+    (sequence_DN0, 3),
+    (sequence_DN0[:, 0], 2),
+    (sequence_DN0[:, :, :, 0], None)
+])
+def test_spectral_axis_raster_index(input_sequence, expected_spectral_axis_raster_index):
+    assert input_sequence._spectral_axis_raster_index == expected_spectral_axis_raster_index
+
+
+@pytest.mark.parametrize("input_sequence, expected_spectral_axis_SnS_index", [
+    (sequence_DN0, 2),
+    (sequence_DN0[:, 0], 1),
+    (sequence_DN0[:, :, :, 0], None)
+])
+def test_spectral_axis_SnS_index(input_sequence, expected_spectral_axis_SnS_index):
+    assert input_sequence._spectral_axis_SnS_index == expected_spectral_axis_SnS_index
+
+
+@pytest.mark.parametrize("input_sequence, expected_raster_axes_types", [
+    (sequence_DN0, (sequence_DN0._raster_axis_name, sequence_DN0._slit_step_axis_name,
+                    sequence_DN0._slit_axis_name, sequence_DN0._spectral_axis_name)),
+
+    (sequence_DN0[:, :, 0, 0], (sequence_DN0._raster_axis_name, sequence_DN0._slit_step_axis_name)),
+
+    #(sequence_DN0[:, 0], (sequence_DN0._raster_axis_name, sequence_DN0._slit_axis_name,
+    #                      sequence_DN0._spectral_axis_name))  # Won't wok until NDCubeSequence._common_axis slicing bug fixed.
+])
+def test_raster_axes_types(input_sequence, expected_raster_axes_types):
+    assert input_sequence.raster_axes_types == expected_raster_axes_types
+
+
+@pytest.mark.parametrize("input_sequence, expected_SnS_axes_types", [
+    (sequence_DN0, (sequence_DN0._SnS_axis_name, sequence_DN0._slit_axis_name,
+                    sequence_DN0._spectral_axis_name)),
+
+    (sequence_DN0[:, :, 0, 0], (sequence_DN0._SnS_axis_name,)),
+
+    #(sequence_DN0[:, 0], (sequence_DN0._SnS_axis_name, sequence_DN0._slit_axis_name,
+    #                      sequence_DN0._spectral_axis_name))  # Won't wok until NDCubeSequence._common_axis slicing bug fixed.
+])
+def test_SnS_axes_types(input_sequence, expected_SnS_axes_types):
+    assert input_sequence.SnS_axes_types == expected_SnS_axes_types


### PR DESCRIPTION
This PR adds awareness to ```RasterSequence``` of its axis types.  This is in addition to```world_axis_physical_types``` which gives the real world coordinates of the axes.  By contrast, these new axis types define the axes as ```'raster'```, ```'slit step'```, ```position along slit'``` and ```'spectral'```.  This information will update as the ```RasterSequence``` as it is sliced etc.

It also breaks ```RasterSequence``` out into its own module, like ```NDCubeSequence``` as the lines of code are now enough to justify that.

This PR addresses Issue #131

To Do
- [ ] Make ```RasterSequence``` axis indices aware of missing axes.  More specifically, make ```RasterSequence._slit_axis_raster_index``` work when slit step axis is missing.  (Possibly the same issue with ```RasterSequence._slit_axis_SnS_index```.
- [ ] Make ```RasterSequence.__str__``` give lat and lon values even if an axis is missing.