### PR TITLE
Bump min ndcube version to 1.3.2

### DIFF
--- a/changelog/162.bugfix.rst
+++ b/changelog/162.bugfix.rst
@@ -1,0 +1,1 @@
+Bump min ndcube version to fix bug caused when OS is bot 64-bit.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
   setuptools_scm
 install_requires =
   sunpy>=1.0.0
-  ndcube>=1.3.0
+  ndcube>=1.3.2
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
This is due to a bug in ndcube caused for non-64-bit OS's.