### PR TITLE
Add intrument_axes attribute to SpectrogramCube.

### DIFF
--- a/changelog/169.feature.rst
+++ b/changelog/169.feature.rst
@@ -1,0 +1,1 @@
+Add optional instrument_axes attribute to SpectrogramCube to enable users to keep track of axes (including through slicing) when axes may have a significance not fully described by the world axis physical types.

--- a/sunraster/spectrogram.py
+++ b/sunraster/spectrogram.py
@@ -1,5 +1,6 @@
 import abc
 import textwrap
+import numbers
 
 import numpy as np
 from ndcube.ndcube import NDCube
@@ -8,6 +9,7 @@ from ndcube.utils.cube import convert_extra_coords_dict_to_input_format
 import astropy.units as u
 
 __all__ = ['SpectrogramCube']
+
 
 # Define some custom error messages.
 APPLY_EXPOSURE_TIME_ERROR = ("Exposure time correction has probably already "
@@ -162,7 +164,7 @@ class SpectrogramCube(NDCube, SpectrogramABC):
     """
 
     def __init__(self, data, wcs, extra_coords=None, unit=None, uncertainty=None, meta=None,
-                 mask=None, copy=False, **kwargs):
+                 mask=None, instrument_axes=None, copy=False, **kwargs):
         # Initialize SpectrogramCube.
         super().__init__(data, wcs, uncertainty=uncertainty, mask=mask, meta=meta, unit=unit,
                          extra_coords=extra_coords, copy=copy, **kwargs)
@@ -180,6 +182,14 @@ class SpectrogramCube(NDCube, SpectrogramABC):
             SUPPORTED_TIME_NAMES, world_axis_physical_types, self_extra_coords)
         self._exposure_time_name, self._exposure_time_loc = _find_axis_name(
             SUPPORTED_EXPOSURE_NAMES, world_axis_physical_types, self_extra_coords)
+
+        # Set up instrument axes is set.
+        if instrument_axes is not None:
+            if len(instrument_axes) != data.ndim:
+                raise ValueError("Number of instrument axes must match number of data axes.")
+            self.instrument_axes = np.asarray(instrument_axes, dtype=str)
+        else:
+            self.instrument_axes = None
 
     def __str__(self):
         if self._time_name:
@@ -214,7 +224,8 @@ class SpectrogramCube(NDCube, SpectrogramABC):
                 {self.__class__.__name__}
                 {"".join(["-"] * len(self.__class__.__name__))}
                 Time Period: {time_period}
-                Pixel dimensions (Slit steps, Slit height, Spectral): {self.dimensions}
+                Instrument axes: {self.instrument_axes}
+                Pixel dimensions: {self.dimensions}
                 Longitude range: {lon_range}
                 Latitude range: {lat_range}
                 Spectral range: {spectral_range}
@@ -224,15 +235,40 @@ class SpectrogramCube(NDCube, SpectrogramABC):
         return f"{object.__repr__(self)}\n{str(self)}"
 
     def __getitem__(self, item):
+        # Slice instrument_axes if they exist.
+        if self.instrument_axes is not None:
+            # If item is int, instrument_axes needs slicing.
+            if isinstance(item, numbers.Integral):
+                instrument_axes = self.instrument_axes[1:]
+            # If item is tuple, instrument axes will need to be sliced if tuple contains an int.
+            elif isinstance(item, tuple):
+                instr_item = [isinstance(i, numbers.Integral) for i in item] + \
+                        [False] * (self.data.ndim - len(item))
+                instrument_axes = self.instrument_axes[np.invert(instr_item)]
+            # If item a slice, cube dimensionality is not reduced
+            # so instrument_axes need not be sliced.
+            else:
+                instrument_axes = self.instrument_axes
+            # If slicing causes cube to be a scalar, set instrument_axes to None.
+            if len(instrument_axes) == 0:
+                instrument_axes = None
+        else:
+            instrument_axes = self.instrument_axes
+
+        # Slice SpectrogramCube using parent slicing.
         result = super().__getitem__(item)
+
+        # As result is an NDCube, must put extra coord back into input format
+        # to create a SpectrogramCube.
         if result.extra_coords is None:
             extra_coords = None
         else:
             extra_coords = convert_extra_coords_dict_to_input_format(result.extra_coords,
                                                                      result.missing_axes)
+
         return self.__class__(result.data, result.wcs, extra_coords, result.unit,
                               result.uncertainty, result.meta, mask=result.mask,
-                              missing_axes=result.missing_axes)
+                              missing_axes=result.missing_axes, instrument_axes=instrument_axes)
 
     @property
     def spectral_axis(self):

--- a/sunraster/tests/test_spectrogram.py
+++ b/sunraster/tests/test_spectrogram.py
@@ -85,7 +85,8 @@ spectrogram_DN_s1 = SpectrogramCube(
     SOURCE_DATA_DN * SINGLES_EXPOSURE_TIME, WCS0, EXTRA_COORDS1, u.ct * u.s,
     SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME)
 spectrogram_NO_COORDS = SpectrogramCube(SOURCE_DATA_DN, WCS_NO_COORDS)
-
+spectrogram_instrument_axes = SpectrogramCube(
+    SOURCE_DATA_DN, WCS0, EXTRA_COORDS0, u.ct, SOURCE_UNCERTAINTY_DN, instrument_axes=("a", "b", "c"))
 
 def test_spectral_axis():
     assert all(spectrogram_DN0.spectral_axis == spectrogram_DN0.axis_world_coords("em.wl"))
@@ -153,3 +154,15 @@ def test_uncalculate_exposure_time_correction_error():
     with pytest.raises(ValueError):
         sunraster.spectrogram._uncalculate_exposure_time_correction(SOURCE_DATA_DN, None, u.ct,
                                                                     EXTRA_COORDS0[1][2])
+
+@pytest.mark.parametrize("item,expected", [
+        (0, np.array(["b", "c"])),
+        (slice(0, 1), np.array(["a", "b", "c"])),
+        ((slice(None), 0), np.array(["a", "c"])),
+        ((slice(None), slice(None), slice(0, 1)), np.array(["a", "b", "c"])),
+        ])
+def test_instrument_axes_slicing(item, expected):
+    sliced_cube = spectrogram_instrument_axes[item]
+    output = sliced_cube.instrument_axes
+    print(output, output.shape, expected, expected.shape)
+    assert all(output == expected)


### PR DESCRIPTION
This PR adds an optional attribute to ```SpectrogramCube``` which gives the instrument axis types.  If not set, it is None.  If set, it is sliced consistently with the cube.  This helps users to keep track of the axis types when axes can be associated with aspects of the instrument and not just physical types, e.g. in a scanning slit spectrograph.