### PR TITLE
Fix time repr in SpectrgramCube for >1D times

### DIFF
--- a/sunraster/spectrogram.py
+++ b/sunraster/spectrogram.py
@@ -186,7 +186,7 @@ class SpectrogramCube(NDCube, SpectrogramABC):
             if self.time.isscalar:
                 time_period = self.time
             else:
-                time_period = (self.time[0], self.time[-1])
+                time_period = (str(self.time.min()), str(self.time.max()))
         else:
             time_period = None
         if self._longitude_name:


### PR DESCRIPTION
This PR ensures only the min and max time are included in ```SpectrogramCube.__str__```.  Previously, the first and last element were included which in the case of >1D time attributes would lead to whole arrays bringing printed.