### PR TITLE
Remove 'sunraster' hyperlinks temporarily due to a theme issue

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,6 +1,6 @@
-=============================
-Contributing to ``sunraster``
-=============================
+=========================
+Contributing to sunraster
+=========================
 
 We are always enthusiastic to welcome new users and developers who want
 to enhance the ``sunraster``.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,5 +1,5 @@
-An Introduction to ``sunraster``
-================================
+An Introduction to sunraster
+============================
 
 ``sunraster`` is a free, open-source, SunPy-affiliated package that provides
 tools to manipulate and visualize slit spectrograph data using the Python


### PR DESCRIPTION
Fixes #166.

Due to some theme (color) issue, removing the `sunraster` hyperlinks temporarily until the said theme issue is resolved. Contrast of hyperlink against background otherwise could pose some accessibility issue. 