### PR TITLE
Remove dev test envs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -68,14 +68,8 @@ jobs:
       - linux: py37-oldestdeps
         name: py37_oldestdeps
 
-      - linux: py38-devdeps
-        name: py38_test_devdeps
-
       - linux: py38-ndcube14dev
         name: py38_ndcube14dev
-
-      - linux: py38-ndcube20dev
-        name: py38_ndcube20dev
 
 # On branches which aren't master, and not Pull Requests, build the wheels but only upload them on tags
 - ${{ if and(ne(variables['Build.Reason'], 'PullRequest'), not(contains(variables['Build.SourceBranch'], 'master'))) }}:

--- a/tox.ini
+++ b/tox.ini
@@ -43,12 +43,12 @@ deps =
     pytest-xdist
     # The devdeps factor is intended to be used to install the latest developer version.
     # of key dependencies.
-    devdeps: cython
-    devdeps: git+https://github.com/astropy/astropy
-    devdeps: git+https://github.com/sunpy/ndcube
-    devdeps: git+https://github.com/sunpy/sunpy
+    #devdeps: cython
+    #devdeps: git+https://github.com/astropy/astropy
+    #devdeps: git+https://github.com/sunpy/ndcube
+    #devdeps: git+https://github.com/sunpy/sunpy
     # Test against dev version of ndcube 2.x with all other deps stable.
-    ndcube20dev: git+https://github.com/sunpy/ndcube
+    #ndcube20dev: git+https://github.com/sunpy/ndcube
     # Test against dev version of ndcube 1.x with all other deps stable.
     ndcube14dev: git+https://github.com/sunpy/ndcube@1.4
     # Oldest deps we pin against.


### PR DESCRIPTION
The Dev dependencies, in particular ndcube, is currently incompatible with the stable version currently used by sunraster 0.2.  Therefore these test envs are removed.