### PR TITLE
Fixed arguments in SpectrogramCube to match NDCube

### DIFF
--- a/changelog/179.bugfix.rst
+++ b/changelog/179.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed arguments in SpectrogramCube to match NDCube.

--- a/sunraster/spectrogram.py
+++ b/sunraster/spectrogram.py
@@ -166,8 +166,8 @@ class SpectrogramCube(NDCube, SpectrogramABC):
     def __init__(self, data, wcs, extra_coords=None, unit=None, uncertainty=None, meta=None,
                  mask=None, instrument_axes=None, copy=False, **kwargs):
         # Initialize SpectrogramCube.
-        super().__init__(data, wcs, uncertainty=uncertainty, mask=mask, meta=meta, unit=unit,
-                         extra_coords=extra_coords, copy=copy, **kwargs)
+        super().__init__(data, wcs=wcs, uncertainty=uncertainty, mask=mask, meta=meta, 
+                         unit=unit, extra_coords=extra_coords, copy=copy, **kwargs)
 
         # Determine labels and location of each key real world coordinate.
         self_extra_coords = self.extra_coords

--- a/sunraster/spectrogram.py
+++ b/sunraster/spectrogram.py
@@ -266,9 +266,10 @@ class SpectrogramCube(NDCube, SpectrogramABC):
             if len(instrument_axes) == 0:
                 instrument_axes = None
 
-        return self.__class__(result.data, result.wcs, extra_coords, result.unit,
-                              result.uncertainty, result.meta, mask=result.mask,
-                              missing_axes=result.missing_axes, instrument_axes=instrument_axes)
+        return self.__class__(result.data, wcs=result.wcs, uncertainty=result.uncertainty,
+                              mask=result.mask, meta=result.meta, unit=result.unit,
+                              extra_coords=extra_coords, missing_axes=result.missing_axes,
+                              instrument_axes=instrument_axes)
 
     @property
     def spectral_axis(self):
@@ -338,7 +339,7 @@ class SpectrogramCube(NDCube, SpectrogramABC):
         # Return new instance of SpectrogramCube with correction applied/undone.
 
         return self.__class__(
-            new_data, self.wcs,
+            new_data, wcs=self.wcs,
             extra_coords=convert_extra_coords_dict_to_input_format(self.extra_coords,
                                                                    self.missing_axes),
             unit=new_unit, uncertainty=new_uncertainty, meta=self.meta, mask=self.mask,

--- a/sunraster/tests/test_spectrogram.py
+++ b/sunraster/tests/test_spectrogram.py
@@ -29,6 +29,7 @@ WCS_NO_COORDS = WCS(header=H_NO_COORDS, naxis=3)
 SOURCE_DATA_DN = np.array([[[0.563, 1.132, -1.343], [-0.719, 1.441, 1.566]],
                            [[0.563, 1.132, -1.343], [-0.719, 1.441, 1.566]]])
 SOURCE_UNCERTAINTY_DN = np.sqrt(SOURCE_DATA_DN)
+MASK = SOURCE_DATA_DN > 1
 
 TIME_DIM_LEN = SOURCE_DATA_DN.shape[0]
 SINGLES_EXPOSURE_TIME = 2.
@@ -45,48 +46,51 @@ EXTRA_COORDS1 = [("time", 0,
 
 # Define SpectrogramCubes in various units.
 spectrogram_DN0 = SpectrogramCube(
-    SOURCE_DATA_DN, WCS0, EXTRA_COORDS0, u.ct, SOURCE_UNCERTAINTY_DN)
+    SOURCE_DATA_DN, wcs=WCS0, extra_coords=EXTRA_COORDS0, unit=u.ct, 
+    uncertainty=SOURCE_UNCERTAINTY_DN)
 spectrogram_DN_per_s0 = SpectrogramCube(
-    SOURCE_DATA_DN / SINGLES_EXPOSURE_TIME, WCS0, EXTRA_COORDS0, u.ct / u.s,
-    SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME)
+    SOURCE_DATA_DN / SINGLES_EXPOSURE_TIME, wcs=WCS0, extra_coords=EXTRA_COORDS0, unit=u.ct / u.s,
+    uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME)
 spectrogram_DN_per_s_per_s0 = SpectrogramCube(
     SOURCE_DATA_DN /
     SINGLES_EXPOSURE_TIME /
     SINGLES_EXPOSURE_TIME,
-    WCS0,
-    EXTRA_COORDS0,
-    u.ct /
+    wcs=WCS0,
+    extra_coords=EXTRA_COORDS0,
+    unit=u.ct /
     u.s /
     u.s,
-    SOURCE_UNCERTAINTY_DN /
+    uncertainty=SOURCE_UNCERTAINTY_DN /
     SINGLES_EXPOSURE_TIME /
     SINGLES_EXPOSURE_TIME)
 spectrogram_DN_s0 = SpectrogramCube(
-    SOURCE_DATA_DN * SINGLES_EXPOSURE_TIME, WCS0, EXTRA_COORDS0, u.ct * u.s,
-    SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME)
+    SOURCE_DATA_DN * SINGLES_EXPOSURE_TIME, wcs=WCS0, extra_coords=EXTRA_COORDS0, unit=u.ct * u.s,
+    uncertainty=SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME)
 spectrogram_DN1 = SpectrogramCube(
-    SOURCE_DATA_DN, WCS0, EXTRA_COORDS1, u.ct, SOURCE_UNCERTAINTY_DN)
+    SOURCE_DATA_DN, wcs=WCS0, extra_coords=EXTRA_COORDS1, unit=u.ct, 
+    uncertainty=SOURCE_UNCERTAINTY_DN)
 spectrogram_DN_per_s1 = SpectrogramCube(
-    SOURCE_DATA_DN / SINGLES_EXPOSURE_TIME, WCS0, EXTRA_COORDS1, u.ct / u.s,
-    SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME)
+    SOURCE_DATA_DN / SINGLES_EXPOSURE_TIME, wcs=WCS0, extra_coords=EXTRA_COORDS1, unit=u.ct / u.s,
+    uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME)
 spectrogram_DN_per_s_per_s1 = SpectrogramCube(
     SOURCE_DATA_DN /
     SINGLES_EXPOSURE_TIME /
     SINGLES_EXPOSURE_TIME,
-    WCS0,
-    EXTRA_COORDS1,
-    u.ct /
+    wcs=WCS0,
+    extra_coords=EXTRA_COORDS1,
+    unit=u.ct /
     u.s /
     u.s,
-    SOURCE_UNCERTAINTY_DN /
+    uncertainty=SOURCE_UNCERTAINTY_DN /
     SINGLES_EXPOSURE_TIME /
     SINGLES_EXPOSURE_TIME)
 spectrogram_DN_s1 = SpectrogramCube(
-    SOURCE_DATA_DN * SINGLES_EXPOSURE_TIME, WCS0, EXTRA_COORDS1, u.ct * u.s,
-    SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME)
+    SOURCE_DATA_DN * SINGLES_EXPOSURE_TIME, wcs=WCS0, extra_coords=EXTRA_COORDS1, unit=u.ct * u.s,
+    uncertainty=SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME)
 spectrogram_NO_COORDS = SpectrogramCube(SOURCE_DATA_DN, WCS_NO_COORDS)
 spectrogram_instrument_axes = SpectrogramCube(
-    SOURCE_DATA_DN, WCS0, EXTRA_COORDS0, u.ct, SOURCE_UNCERTAINTY_DN, instrument_axes=("a", "b", "c"))
+    SOURCE_DATA_DN, wcs=WCS0, extra_coords=EXTRA_COORDS0, unit=u.ct, 
+    uncertainty=SOURCE_UNCERTAINTY_DN, mask=MASK, instrument_axes=("a", "b", "c"))
 
 def test_spectral_axis():
     assert all(spectrogram_DN0.spectral_axis == spectrogram_DN0.axis_world_coords("em.wl"))


### PR DESCRIPTION
### Description

Fixes the interface of `SpectrogramCube` so that it works with recent versions of `ndcube`.
