### PR TITLE
Update exposure_time properties to use exposure time from Meta object.

### DIFF
--- a/docs/data_types/spectrogram.rst
+++ b/docs/data_types/spectrogram.rst
@@ -162,23 +162,25 @@ An important step in analyzing any form of photon-based observations is normaliz
 This is important both for converting between instrumental and physical units, e.g. DN to energy, and comparing spectral features between exposure, e.g. line intensity.
 
 `~sunraster.SpectrogramCube` provides a simple API for performing this correction: `~sunraster.SpectrogramCube.apply_exposure_time_correction`.
-It requires that the exposure time is stored the WCS or as a `~astropy.units.Quantity` in the `~sunraster.SpectrogramCube.extra_coords` property.
+It requires that the exposure time is stored in the ``.meta`` attribute of the `~sunraster.SpectromCube` as a `~astropy.units.Quantity`.
+The ``.meta`` attribute must be an instance of `~sunraster.extern.meta.Meta`.
 Let's recreate our spectrogram object again, but this time with exposure times of 0.5 seconds stored as an extra coordinate and a data unit of counts.
 
 .. code-block:: python
 
     >>> import astropy.units as u
+    >>> from sunraster.extern.meta import Meta
     >>> exposure_times = np.ones(data.shape[0])/2 * u.s
-    >>> extra_coords_input = [("exposure time", 0, exposure_times)]
+    >>> # Create a metadata instance to hold the exposure times.
+    >>> # We must also assign the exposure time to the time axis, in this case, the 0th array axis.
+    >>> metadata = Meta({"exposure time": exposure_times}, axes={"exposure time": 0},
+    ...                 data_shape=data.shape)
     >>> my_spectrograms = SpectrogramCube(data, input_wcs, uncertainty=uncertainties,
-    ...                                   mask=mask, meta=meta, unit=u.ct)
-    >>> [my_spectrograms.extra_coords.add(*extra) for extra in extra_coords_input]
-    [None]
+    ...                                   mask=mask, meta=metadata, unit=u.ct)
 
-Note that the API for supplying extra coordinates is an iterable of tuples of the form (``str``, ``int``, `~astropy.units.Quantity` or array-like).
-The 0th entry gives the name of the coordinate, the 1st entry gives the data axis to which the extra coordinate corresponds, and the 2nd entry gives the value of that coordinate at each pixel along the axis.
-Also note that the coordinate array must be the same length as its corresponding data axis.
-See the `NDCube extra coordinates documentation <https://docs.sunpy.org/projects/ndcube/en/stable/ndcube.html#extra-coordinates>`__ for more.
+Note that the API for supplying metadata allows us to supply an additional `dict` designating which axes the metadata corresponds.
+We must also supply the shape of the data array with which the metadata is associated to enable it to be preserved through slicing operations.
+Also note that the metadata array must be the same shape as its corresponding data axes.
 
 Applying the exposure time correction is now simple.
 

--- a/sunraster/tests/test_spectrogram.py
+++ b/sunraster/tests/test_spectrogram.py
@@ -7,6 +7,7 @@ from ndcube.tests.helpers import assert_cubes_equal
 
 import sunraster.spectrogram
 from sunraster import SpectrogramCube
+from sunraster.extern.meta import Meta
 
 # Define a sample wcs object
 H0 = {
@@ -74,13 +75,15 @@ EXTRA_COORDS1 = [
         (Time("2017-01-01") + TimeDelta(np.arange(TIME_DIM_LEN, TIME_DIM_LEN * 2), format="sec")),
     ),
 ]
+meta_exposure0 = Meta({"exposure time": EXPOSURE_TIME}, axes={"exposure time": 0},
+                      data_shape=SOURCE_DATA_DN.shape)
 
 spectrogram_DN0 = SpectrogramCube(
     SOURCE_DATA_DN,
     wcs=WCS0,
     unit=u.ct,
     uncertainty=SOURCE_UNCERTAINTY_DN,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_per_s0 = SpectrogramCube(
@@ -88,7 +91,7 @@ spectrogram_DN_per_s0 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct / u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_per_s_per_s0 = SpectrogramCube(
@@ -96,7 +99,7 @@ spectrogram_DN_per_s_per_s0 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct / u.s / u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s_per_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_s0 = SpectrogramCube(
@@ -104,7 +107,7 @@ spectrogram_DN_s0 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct * u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN1 = SpectrogramCube(
@@ -112,7 +115,7 @@ spectrogram_DN1 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct,
     uncertainty=SOURCE_UNCERTAINTY_DN,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN1.extra_coords.add(*EXTRA_COORDS1[0])
 spectrogram_DN_per_s1 = SpectrogramCube(
@@ -120,7 +123,7 @@ spectrogram_DN_per_s1 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct / u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s1.extra_coords.add(*EXTRA_COORDS1[0])
 spectrogram_DN_per_s_per_s1 = SpectrogramCube(
@@ -128,7 +131,7 @@ spectrogram_DN_per_s_per_s1 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct / u.s / u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s_per_s1.extra_coords.add(*EXTRA_COORDS1[0])
 spectrogram_DN_s1 = SpectrogramCube(
@@ -136,7 +139,7 @@ spectrogram_DN_s1 = SpectrogramCube(
     wcs=WCS0,
     unit=u.ct * u.s,
     uncertainty=SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_s1.extra_coords.add(*EXTRA_COORDS1[0])
 spectrogram_NO_COORDS = SpectrogramCube(SOURCE_DATA_DN, WCS_NO_COORDS)
@@ -147,7 +150,7 @@ spectrogram_instrument_axes = SpectrogramCube(
     uncertainty=SOURCE_UNCERTAINTY_DN,
     mask=MASK,
     instrument_axes=("a", "b", "c"),
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_instrument_axes.extra_coords.add(*EXTRA_COORDS0[0])
 

--- a/sunraster/tests/test_spectrogramsequence.py
+++ b/sunraster/tests/test_spectrogramsequence.py
@@ -6,6 +6,7 @@ from astropy.wcs import WCS
 from ndcube.tests.helpers import assert_cubesequences_equal
 
 from sunraster import RasterSequence, SpectrogramCube, SpectrogramSequence
+from sunraster.extern.meta import Meta
 
 # Define an sample wcs objects.
 H0 = {
@@ -117,7 +118,13 @@ extra_coords21 = [
 # Define meta data
 meta_seq = {
     "a": 0,
-}  # "exposure time": EXPOSURE_TIME}
+}
+meta_exposure0 = Meta({"exposure time": EXPOSURE_TIME}, axes={"exposure time": 0},
+                      data_shape=SOURCE_DATA_DN.shape)
+meta_exposure2 = Meta(
+    {"exposure time": u.Quantity(np.zeros(SOURCE_DATA_DN.shape[2]) + SINGLES_EXPOSURE_TIME,
+                                 unit=u.s)},
+    axes={"exposure time": 2}, data_shape=SOURCE_DATA_DN.shape)
 
 # Define RasterSequences in various units.
 spectrogram_DN0 = SpectrogramCube(
@@ -125,7 +132,7 @@ spectrogram_DN0 = SpectrogramCube(
     WCS0,
     u.ct,
     SOURCE_UNCERTAINTY_DN,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0,
 )
 spectrogram_DN0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN1 = SpectrogramCube(
@@ -133,7 +140,7 @@ spectrogram_DN1 = SpectrogramCube(
     WCS0,
     u.ct,
     SOURCE_UNCERTAINTY_DN,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0,
 )
 spectrogram_DN1.extra_coords.add(*EXTRA_COORDS1[0])
 sequence_DN = RasterSequence([spectrogram_DN0, spectrogram_DN1], meta=meta_seq, common_axis=0)
@@ -146,9 +153,7 @@ spectrogram_DN20 = SpectrogramCube(
     wcs2,
     u.ct,
     SOURCE_UNCERTAINTY_DN,
-    meta={
-        "exposure time": u.Quantity(np.zeros(SOURCE_DATA_DN.shape[2]) + SINGLES_EXPOSURE_TIME, unit=u.s),
-    },
+    meta=meta_exposure2
 )
 spectrogram_DN20.extra_coords.add(*extra_coords20[0])
 spectrogram_DN21 = SpectrogramCube(
@@ -156,9 +161,7 @@ spectrogram_DN21 = SpectrogramCube(
     wcs2,
     u.ct,
     SOURCE_UNCERTAINTY_DN,
-    meta={
-        "exposure time": u.Quantity(np.zeros(SOURCE_DATA_DN.shape[2]) + SINGLES_EXPOSURE_TIME, unit=u.s),
-    },
+    meta=meta_exposure2
 )
 spectrogram_DN21.extra_coords.add(*extra_coords21[0])
 sequence_DN2 = RasterSequence([spectrogram_DN20, spectrogram_DN21], meta=meta_seq, common_axis=2)
@@ -168,7 +171,7 @@ spectrogram_DN_per_s0 = SpectrogramCube(
     WCS0,
     u.ct / u.s,
     SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_per_s1 = SpectrogramCube(
@@ -176,7 +179,7 @@ spectrogram_DN_per_s1 = SpectrogramCube(
     WCS0,
     u.ct / u.s,
     SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s1.extra_coords.add(*EXTRA_COORDS1[0])
 sequence_DN_per_s = RasterSequence([spectrogram_DN_per_s0, spectrogram_DN_per_s1], meta=meta_seq, common_axis=0)
@@ -185,7 +188,7 @@ spectrogram_DN_per_s_per_s0 = SpectrogramCube(
     WCS0,
     u.ct / u.s / u.s,
     SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s_per_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_per_s_per_s1 = SpectrogramCube(
@@ -193,7 +196,7 @@ spectrogram_DN_per_s_per_s1 = SpectrogramCube(
     WCS0,
     u.ct / u.s / u.s,
     SOURCE_UNCERTAINTY_DN / SINGLES_EXPOSURE_TIME / SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_per_s_per_s1.extra_coords.add(*EXTRA_COORDS1[0])
 sequence_DN_per_s_per_s = RasterSequence(
@@ -206,7 +209,7 @@ spectrogram_DN_s0 = SpectrogramCube(
     WCS0,
     u.ct * u.s,
     SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_s0.extra_coords.add(*EXTRA_COORDS0[0])
 spectrogram_DN_s1 = SpectrogramCube(
@@ -214,7 +217,7 @@ spectrogram_DN_s1 = SpectrogramCube(
     WCS0,
     u.ct * u.s,
     SOURCE_UNCERTAINTY_DN * SINGLES_EXPOSURE_TIME,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 spectrogram_DN_s1.extra_coords.add(*EXTRA_COORDS1[0])
 sequence_DN_s = RasterSequence([spectrogram_DN_s0, spectrogram_DN_s1], meta=meta_seq, common_axis=0)
@@ -224,14 +227,14 @@ raster_no_wave0 = SpectrogramCube(
     SOURCE_DATA_DN[:, :, 0],
     wcs_no_wave,
     u.ct,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 raster_no_wave0.extra_coords.add(*EXTRA_COORDS0[0])
 raster_no_wave1 = SpectrogramCube(
     SOURCE_DATA_DN[:, :, 0],
     wcs_no_wave,
     u.ct,
-    meta={"exposure time": EXPOSURE_TIME},
+    meta=meta_exposure0
 )
 raster_no_wave1.extra_coords.add(*EXTRA_COORDS0[0])
 sequence_DN_no_wave = RasterSequence([raster_no_wave0, raster_no_wave1], 0)


### PR DESCRIPTION
Hi @nabobalis.  This PR is the result of trying to answer your comment question [here](https://github.com/sunpy/sunraster/pull/184/commits/1bf85774a063e6696313c8a60eda383e619266d8#diff-700a3462d608adc85ab8a5e9cdec91e374215a187101945d745d0f98ad207964R436) regarding why you had to transpose the data.

The answer is that transposing did not fix the problem.  It just enabled it to give a wrong answer without erroring.  The real issue was that the method found the spectral axis when is should have been finding the axis to which the exposure time corresponded.  Fixing that bug then led me to update the code and tests to work when exposure time was stored in the new `Meta` instance.

<!--
We know that working on code and submitting pull requests takes effort, and we appreciate your time.
Thank you.

Please be aware that everyone has to follow our code of conduct:
https://sunpy.org/coc

Furthermore, you might need to check with your work place if you are allowed to contribute code:
https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html

Also these comments are hidden when you submit this github pull request.

We have several automatic features that run when a pull request is open.
They can appear daunting but do not worry about them!
Here is a brief explanation of them:
https://docs.sunpy.org/en/latest/dev_guide/contents/pr_review_procedure.html#continuous-integration
-->

### Description

<!--
Provide a general description of what your pull request does.

If the pull request closes any open issues you can add this.
If you replace <Issue Number> with a number GitHub will automatically link it.
If it doesn't, please remove the following line.
-->

Fixes #<Issue Number>
