### PR TITLE
Fixes Issue 196 - read_spice_l2_fits function fails to load wide-slit SPICE FITS files

### DIFF
--- a/sunraster/instr/spice.py
+++ b/sunraster/instr/spice.py
@@ -111,7 +111,7 @@ def read_spice_l2_fits(filenames, windows=None, memmap=True, read_dumbbells=Fals
             aligned_axes = tuple(range(len(first_sequence.dimensions)))
         else:
             aligned_axes = tuple(
-                i for i, phys_type in enumerate(first_sequence.array_axis_physical_types) if phys_type != ("em.wl",)
+                i for i, phys_type in enumerate(first_sequence.array_axis_physical_types) if "em.wl" not in phys_type
             )
     else:
         aligned_axes = None


### PR DESCRIPTION
## PR Description

This change allows the function read_spice_l2_fits to load wide-slit SPICE FITS files. 
Previously, this failed because the wavelength axis is not exclusively associated with wavelength. (It is mixed with HP Latitude and Longitude.) Now, alignment of said axis is not enforced. 

See: https://github.com/sunpy/sunraster/issues/196
