### PR TITLE
Exclude HDUs for additional distortion information

### DIFF
--- a/changelog/215.bugfix.rst
+++ b/changelog/215.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed SPICE reader failing on FITS files containing ``WCSDVARR`` HDUs (with additional distortion information), by ignoring these HDUs.

--- a/sunraster/instr/spice.py
+++ b/sunraster/instr/spice.py
@@ -169,6 +169,7 @@ def _read_single_spice_l2_fits(
     """
     window_cubes = []
     dumbbell_label = "DUMBBELL"
+    excluded_labels = ["LOSTPLNPIXLIST", "WCSDVARR"]
     with fits.open(filename, memmap=memmap) as hdulist:
         if isinstance(spice_id, numbers.Integral) and hdulist[0].header["SPIOBSID"] != spice_id:
             raise ValueError(f"{INCORRECT_OBSID_MESSAGE} Expected {spice_id}. Got {hdulist[0].header['SPIOBSID']}.")
@@ -187,6 +188,7 @@ def _read_single_spice_l2_fits(
                     for hdu in hdulist
                     if (isinstance(hdu, fits.hdu.image.PrimaryHDU) or isinstance(hdu, fits.hdu.image.ImageHDU))
                     and dumbbell_label not in hdu.header["EXTNAME"]
+                    and hdu.header["EXTNAME"] not in excluded_labels
                 ]
         dumbbells_requested = [dumbbell_label in window for window in windows]
         if any(dumbbells_requested) and not all(dumbbells_requested):

--- a/sunraster/instr/spice.py
+++ b/sunraster/instr/spice.py
@@ -169,7 +169,7 @@ def _read_single_spice_l2_fits(
     """
     window_cubes = []
     dumbbell_label = "DUMBBELL"
-    excluded_labels = ["LOSTPLNPIXLIST", "WCSDVARR"]
+    excluded_labels = ["WCSDVARR"]
     with fits.open(filename, memmap=memmap) as hdulist:
         if isinstance(spice_id, numbers.Integral) and hdulist[0].header["SPIOBSID"] != spice_id:
             raise ValueError(f"{INCORRECT_OBSID_MESSAGE} Expected {spice_id}. Got {hdulist[0].header['SPIOBSID']}.")


### PR DESCRIPTION
Solves #208 : `read_spice_l2_fits` failed on files with additional distortion information, which is stored in the WCSDVARR ImageHDUs. The code wrongly interpreted these as spectral windows HDUs, and this resulted in an error, as described in #208.

This PR (my first one in a SunPy affiliated project) is simply to ignore these HDUs containing distortion information.

Distortion from the instrument optics is already corrected in SPICE L2 FITS files, but the additional distortion in the WCSDVARR HDUs is the one that comes from spacecraft pointing changes, as obtained by the pipeline from the Solar Orbiter SPICE kernels.

In the future, a SPICE FITS file reader should have the option to take into account this information instead of ignoring it. How this should be done is still unclear, a possibility is to reproject on a non-distorted grid, but this has drawbacks, and requires deciding what to do in problematic cases (e.g. when pointing jitter in the scanning direction is larger than the raster step).