### PR TITLE
Fix link to newcomers' guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ For more information on contributing to sunraster, please read SunPy's `Newcomer
 .. _Developers Guide: https://docs.sunpy.org/en/latest/dev_guide/index.html
 .. _`#sunpy:openastronomy.org`: https://chat.openastronomy.org/#/room/#sunpy:openastronomy.org
 .. _issues page: https://github.com/sunpy/sunraster/issues
-.. _Newcomers' guide: https://docs.sunpy.org/en/latest/dev_guide/newcomers.html
+.. _Newcomers' guide: https://docs.sunpy.org/en/latest/dev_guide/contents/newcomers.html
 
 Code of Conduct
 ===============


### PR DESCRIPTION
This PR updates the link to the Newcomers' guide to point to the correct page (current link gets a 404).
