### PR TITLE
correcting units in spice.py

### DIFF
--- a/sunraster/instr/spice.py
+++ b/sunraster/instr/spice.py
@@ -229,7 +229,7 @@ def _read_single_spice_l2_fits(
                     data=data,
                     wcs=wcs,
                     mask=np.isnan(data),
-                    unit=u.adu,
+                    unit=u.Unit(meta.get("BUNIT"), format="fits"),
                     meta=meta,
                     instrument_axes=("raster scan", "spectral", "slit", "slit step"),
                 )


### PR DESCRIPTION
The units of the SPICE level 2 were hardcoded in spice.py as u.adu, whereas these can be obtained from the fits header (L2 should be W/m^2/sr/nm. The u.adu was causing some issues when dealing with NDUncertainty.
