### PR TITLE
remove old circleci webhook config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,3 @@ workflows:
   pip-install:
     jobs:
       - pip-install
-
-notify:
-  webhooks:
-    - url: https://giles.cadair.dev/circleci


### PR DESCRIPTION
This repo also isn't using the webhooks, but they are now configured in the web UI for good measure.